### PR TITLE
replace Linux command with MacOS command to get number of processors

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ set -e
 OPTIONS=snrp:
 
 shell=n nodep=n revise=n
-procs=$(grep -c \^processor /proc/cpuinfo)
+procs=$(sysctl -n hw.ncpu)
 
 while getopts $OPTIONS varname; do
     case "$varname" in


### PR DESCRIPTION
One small change to get this branch to work on MacOS!

(Although you still need to downgrade Julia to 1.1.1).